### PR TITLE
update core_version_requirement for Drupal 10

### DIFF
--- a/video_embed_cornell_cast.info.yml
+++ b/video_embed_cornell_cast.info.yml
@@ -1,7 +1,7 @@
 name: Video Embed Cornell Cast
 type: module
 description: Helps to properly embed cornell cast videos.
-core_version_requirement: ^8.8 || ^9
+core_version_requirement: ^9 || ^10
 package: Custom
 dependencies:
   - video_embed_field


### PR DESCRIPTION
Upgrade Status doesn't report any D10 compatibility blockers for this module other than the core_version_requirement thing -- so far.